### PR TITLE
pref(cbc): turn panic into friendly and controllable errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 *.out
 
 .idea
+
+# go-mod cache
+vendor

--- a/cbc.go
+++ b/cbc.go
@@ -2,6 +2,7 @@ package openssl
 
 import (
 	"crypto/cipher"
+	"errors"
 )
 
 // CBCEncrypt
@@ -10,6 +11,10 @@ func CBCEncrypt(block cipher.Block, src, iv []byte, padding string) ([]byte, err
 	src = Padding(padding, src, blockSize)
 
 	encryptData := make([]byte, len(src))
+
+	if len(iv) != block.BlockSize() {
+		return nil, errors.New("CBCEncrypt: IV length must equal block size")
+	}
 
 	mode := cipher.NewCBCEncrypter(block, iv)
 	mode.CryptBlocks(encryptData, src)
@@ -21,6 +26,10 @@ func CBCEncrypt(block cipher.Block, src, iv []byte, padding string) ([]byte, err
 func CBCDecrypt(block cipher.Block, src, iv []byte, padding string) ([]byte, error) {
 
 	dst := make([]byte, len(src))
+
+	if len(iv) != block.BlockSize() {
+		return nil, errors.New("CBCDecrypt: IV length must equal block size")
+	}
 
 	mode := cipher.NewCBCDecrypter(block, iv)
 	mode.CryptBlocks(dst, src)


### PR DESCRIPTION
> reference issuce for #13 

pref(cbc): turn panic into friendly and controllable errors
pref: gitignore vendor

> test code like [conero/tests/algorithm_test](https://github.com/conero/openssl/blob/conero/tests/algorithm_test.go)


```go
func TestAlgorithm_Encode_all(t *testing.T) {
	// 随机密文
	key := str.RandStr.SafeStr(32)
	origin := str.RandStr.SafeStr(500) + "中华人民共和国-贵州.贵阳"

	for _, algStr := range algList {
		alg := NewAlgorithm(algStr, key)
		cp, err := alg.Encode(origin)
		if err != nil {
			t.Errorf("算法 %v 加密错误，%v", algStr, err)
		}

		// 解密参照
		refOrigin, er := alg.Decode(cp)
		if er != nil {
			t.Errorf("算法 %v 解密错误，%v", algStr, err)
		}

		if refOrigin != origin {
			t.Errorf("算法 %v 加解密错误，\n 秘钥 %v", algStr, key)
		}

		// 成功显示
		t.Logf("√ => 算法 %v 通过测试，加解密无误", algStr)
	}
}
© 2022 GitHub, Inc.
Terms

```

